### PR TITLE
Prevent getQueryParameters to be executed more than once

### DIFF
--- a/src/main/java/net/uiqui/embedhttp/Router.java
+++ b/src/main/java/net/uiqui/embedhttp/Router.java
@@ -1,7 +1,7 @@
 package net.uiqui.embedhttp;
 
 import net.uiqui.embedhttp.api.HttpRequestHandler;
-import net.uiqui.embedhttp.api.impl.RouterImpl;
+import net.uiqui.embedhttp.routing.RouterImpl;
 
 /**
  * Interface for a router that maps HTTP request paths to handlers.

--- a/src/main/java/net/uiqui/embedhttp/api/impl/Lazy.java
+++ b/src/main/java/net/uiqui/embedhttp/api/impl/Lazy.java
@@ -1,0 +1,27 @@
+package net.uiqui.embedhttp.api.impl;
+
+import java.util.function.Supplier;
+
+public class Lazy<T> {
+    private Supplier<T> supplier;
+    private T value;
+    private boolean isInitialized = false;
+
+    private Lazy(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    public T get() {
+        if (!isInitialized) {
+            value = supplier.get();
+            isInitialized = true;
+            supplier = null;
+        }
+
+        return value;
+    }
+
+    public static <T> Lazy<T> of(Supplier<T> supplier) {
+        return new Lazy<>(supplier);
+    }
+}

--- a/src/main/java/net/uiqui/embedhttp/routing/RouterImpl.java
+++ b/src/main/java/net/uiqui/embedhttp/routing/RouterImpl.java
@@ -1,5 +1,6 @@
-package net.uiqui.embedhttp.api.impl;
+package net.uiqui.embedhttp.routing;
 
+import net.uiqui.embedhttp.api.impl.HttpRequestImpl;
 import net.uiqui.embedhttp.server.Request;
 
 import java.util.HashMap;

--- a/src/main/java/net/uiqui/embedhttp/routing/RoutingBuilder.java
+++ b/src/main/java/net/uiqui/embedhttp/routing/RoutingBuilder.java
@@ -1,9 +1,8 @@
-package net.uiqui.embedhttp.api.impl;
+package net.uiqui.embedhttp.routing;
 
 import net.uiqui.embedhttp.Router;
 import net.uiqui.embedhttp.api.HttpMethod;
 import net.uiqui.embedhttp.api.HttpRequestHandler;
-import net.uiqui.embedhttp.routing.Route;
 
 import java.util.ArrayList;
 import java.util.EnumMap;

--- a/src/main/java/net/uiqui/embedhttp/server/RequestProcessor.java
+++ b/src/main/java/net/uiqui/embedhttp/server/RequestProcessor.java
@@ -4,7 +4,7 @@ import net.uiqui.embedhttp.api.ContentType;
 import net.uiqui.embedhttp.api.HttpResponse;
 import net.uiqui.embedhttp.api.impl.HttpRequestImpl;
 import net.uiqui.embedhttp.api.impl.HttpResponseImpl;
-import net.uiqui.embedhttp.api.impl.RouterImpl;
+import net.uiqui.embedhttp.routing.RouterImpl;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,7 +55,7 @@ public class RequestProcessor {
     }
 
     private HttpResponse execute(HttpRequestImpl httpRequest) {
-        var handler = httpRequest.route().getHandler();
+        var handler = httpRequest.getRoute().getHandler();
 
         try {
             return handler.handle(httpRequest);

--- a/src/main/java/net/uiqui/embedhttp/server/ServerInstance.java
+++ b/src/main/java/net/uiqui/embedhttp/server/ServerInstance.java
@@ -2,7 +2,7 @@ package net.uiqui.embedhttp.server;
 
 import net.uiqui.embedhttp.HttpServer;
 import net.uiqui.embedhttp.Router;
-import net.uiqui.embedhttp.api.impl.RouterImpl;
+import net.uiqui.embedhttp.routing.RouterImpl;
 import net.uiqui.embedhttp.server.state.ServerState;
 import net.uiqui.embedhttp.server.state.StateMachine;
 

--- a/src/test/java/net/uiqui/embedhttp/api/impl/HttpRequestImplTest.java
+++ b/src/test/java/net/uiqui/embedhttp/api/impl/HttpRequestImplTest.java
@@ -80,6 +80,28 @@ class HttpRequestImplTest {
     }
 
     @Test
+    void testExtractQueryParametersWithEmojis() {
+        // given
+        var request = new Request(HttpMethod.GET, "/test/path?q=%F0%9F%92%A1", null, null);
+        var classUnderTest = new HttpRequestImpl(request, null, null);
+        // when
+        var result = classUnderTest.extractQueryParameters();
+        // then
+        assertThat(result).containsEntry("q", "\uD83D\uDCA1");
+    }
+
+    @Test
+    void testExtractQueryParametersWhenURLHasNoQuery() {
+        // given
+        var request = new Request(HttpMethod.GET, "/test/path", null, null);
+        var classUnderTest = new HttpRequestImpl(request, null, null);
+        // when
+        var result = classUnderTest.extractQueryParameters();
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     void testGetHeaders() {
         // given
         var headers = InsensitiveMap.from(Map.of("header1", "value1", "header2", "value2"));
@@ -109,7 +131,7 @@ class HttpRequestImplTest {
         var request = new Request(HttpMethod.GET, "/", null, null);
         var classUnderTest = new HttpRequestImpl(request, null, null);
         // when
-        var result = classUnderTest.request();
+        var result = classUnderTest.getRequest();
         // then
         assertThat(result).isEqualTo(request);
     }
@@ -120,7 +142,7 @@ class HttpRequestImplTest {
         var route = new Route(HttpMethod.GET, "/", null);
         var classUnderTest = new HttpRequestImpl(null, route, null);
         // when
-        var result = classUnderTest.route();
+        var result = classUnderTest.getRoute();
         // then
         assertThat(result).isEqualTo(route);
     }
@@ -128,7 +150,7 @@ class HttpRequestImplTest {
     @Test
     void testGetPathParameters() {
         // given
-        var pathParameters = InsensitiveMap.from(Map.of("param1", "value1", "param2", "value2"));
+        var pathParameters = Map.of("param1", "value1", "param2", "value2");
         var classUnderTest = new HttpRequestImpl(null, null, pathParameters);
         // when
         var result = classUnderTest.getPathParameters();

--- a/src/test/java/net/uiqui/embedhttp/api/impl/LazyTest.java
+++ b/src/test/java/net/uiqui/embedhttp/api/impl/LazyTest.java
@@ -1,0 +1,33 @@
+package net.uiqui.embedhttp.api.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LazyTest {
+
+    @Test
+    void testGetExecutesSupplier() {
+        // given
+        var lazy = Lazy.of(() -> "Hello, World!");
+        // when
+        var result = lazy.get();
+        // then
+        assertThat(result).isEqualTo("Hello, World!");
+    }
+
+    @Test
+    void testGetSupplierIsCalledOnlyOnce() {
+        // given
+        var counter = new AtomicInteger();
+        var lazy = Lazy.of(counter::incrementAndGet);
+        // then
+        var result = lazy.get();
+        assertThat(result).isEqualTo(1);
+        // then again
+        result = lazy.get();
+        assertThat(result).isEqualTo(1);
+    }
+}

--- a/src/test/java/net/uiqui/embedhttp/routing/RouterImplTest.java
+++ b/src/test/java/net/uiqui/embedhttp/routing/RouterImplTest.java
@@ -1,4 +1,4 @@
-package net.uiqui.embedhttp.api.impl;
+package net.uiqui.embedhttp.routing;
 
 import net.uiqui.embedhttp.Router;
 import net.uiqui.embedhttp.api.HttpMethod;
@@ -19,9 +19,9 @@ class RouterImplTest {
         var result = classUnderTest.routeRequest(request);
         // then
         assertThat(result).isNotNull();
-        assertThat(result.route().getMethod()).isEqualTo(HttpMethod.GET);
-        assertThat(result.route().getPathPattern()).isEqualTo("/get");
-        assertThat(result.request()).isEqualTo(request);
+        assertThat(result.getRoute().getMethod()).isEqualTo(HttpMethod.GET);
+        assertThat(result.getRoute().getPathPattern()).isEqualTo("/get");
+        assertThat(result.getRequest()).isEqualTo(request);
     }
 
     @Test
@@ -33,9 +33,9 @@ class RouterImplTest {
         var result = classUnderTest.routeRequest(request);
         // then
         assertThat(result).isNotNull();
-        assertThat(result.route().getMethod()).isEqualTo(HttpMethod.PUT);
-        assertThat(result.route().getPathPattern()).isEqualTo("/put/:id");
-        assertThat(result.request()).isEqualTo(request);
+        assertThat(result.getRoute().getMethod()).isEqualTo(HttpMethod.PUT);
+        assertThat(result.getRoute().getPathPattern()).isEqualTo("/put/:id");
+        assertThat(result.getRequest()).isEqualTo(request);
         assertThat(result.getPathParameters()).containsEntry("id", "123");
     }
 
@@ -70,9 +70,9 @@ class RouterImplTest {
         var result = classUnderTest.routeRequest(request);
         // then
         assertThat(result).isNotNull();
-        assertThat(result.route().getMethod()).isEqualTo(HttpMethod.POST);
-        assertThat(result.route().getPathPattern()).isEqualTo("/v1/resource/:id/section/:name");
-        assertThat(result.request()).isEqualTo(request);
+        assertThat(result.getRoute().getMethod()).isEqualTo(HttpMethod.POST);
+        assertThat(result.getRoute().getPathPattern()).isEqualTo("/v1/resource/:id/section/:name");
+        assertThat(result.getRequest()).isEqualTo(request);
         assertThat(result.getPathParameters()).containsEntry("id", "123");
         assertThat(result.getPathParameters()).containsEntry("name", "abc");
     }

--- a/src/test/java/net/uiqui/embedhttp/routing/RoutingBuilderTest.java
+++ b/src/test/java/net/uiqui/embedhttp/routing/RoutingBuilderTest.java
@@ -1,10 +1,9 @@
-package net.uiqui.embedhttp.api.impl;
+package net.uiqui.embedhttp.routing;
 
 import net.uiqui.embedhttp.Router;
 import net.uiqui.embedhttp.api.HttpMethod;
 import net.uiqui.embedhttp.api.HttpRequestHandler;
 import net.uiqui.embedhttp.api.HttpResponse;
-import net.uiqui.embedhttp.routing.Route;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/net/uiqui/embedhttp/server/RequestProcessorTest.java
+++ b/src/test/java/net/uiqui/embedhttp/server/RequestProcessorTest.java
@@ -3,7 +3,7 @@ package net.uiqui.embedhttp.server;
 import net.uiqui.embedhttp.Router;
 import net.uiqui.embedhttp.api.ContentType;
 import net.uiqui.embedhttp.api.HttpResponse;
-import net.uiqui.embedhttp.api.impl.RouterImpl;
+import net.uiqui.embedhttp.routing.RouterImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
If getQueryParameter(String name) is executed multiple times, the underline getQueryParameters where executed every time, and this method parsed the query on every request. Was introduced a lazy data type that uses a supplier to obtain the query parameters, this way we only parsed the query once.